### PR TITLE
Feat: load environment vars in remote dev environments

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -418,15 +418,18 @@ module.exports = () => {
 			new Dotenv(
 				Object.assign(
 					{},
-					isEnvDevelopment && {
-						path: path.resolve(paths.appPath, '.env')
-					},
+					isEnvDevelopment &&
+						!isRemoteDevelopment && {
+							path: path.resolve(paths.appPath, '.env')
+						},
 					{
-						// Load all system variables as well, useful during CI builds
-						systemvars: isEnvProduction,
+						// Load all system variables as well, useful during CI builds and in Remote Dev environments
+						systemvars: isEnvProduction || isRemoteDevelopment,
 						// load '.env.example'
 						safe:
-							isEnvDevelopment && path.resolve(paths.appPath, '.env.example')
+							isEnvDevelopment &&
+							!isRemoteDevelopment &&
+							path.resolve(paths.appPath, '.env.example')
 					}
 				)
 			)


### PR DESCRIPTION
This makes system(environment) variables to be loaded into the app in remote dev environments like Gitpod.

The reasoning for this is incase the app is cloned or opened in a remote dev environment such as Gitpod using `npm run start:remote-dev` environment variables that the app requires such as `RAPID_API_KEY` which may be available in the terminal session will be loaded into the app.